### PR TITLE
Allow overriding of HTTP method used for request_token and access_token

### DIFF
--- a/README
+++ b/README
@@ -54,6 +54,15 @@ look something like:
         'https://oauth.provider/access_token' \
         credentials
 
+The default HTTP method used for the request_token and access_token URLs
+is POST.  If you want to change that, set environment variables
+CURLICUE_REQUEST_TOKEN_METHOD and/or CURLICUE_ACCESS_TOKEN_METHOD,
+respectively, before you run curlicue-setup.  For example,
+    
+    export CURLICUE_REQUEST_TOKEN_METHOD=GET
+    export CURLICUE_ACCESS_TOKEN_METHOD=GET
+    # run curlicue-setup command as shown above
+
 In the user authorization URL (only), variables from the consumer
 information or request token can be interpolated using shell syntax.
 Your provider may need additional URL parameters for one or more of the

--- a/curlicue-setup
+++ b/curlicue-setup
@@ -22,13 +22,13 @@ read -p 'Consumer secret: ' secret
 curl-encode "oauth_consumer_key=$key" "oauth_consumer_secret=$secret" > "$consumer_tmp"
 
 curlicue -f "$consumer_tmp" -p 'oauth_callback=oob' -- \
-    -s -X POST "$request_token_url" > "$request_token_tmp"
+    -s -X ${CURLICUE_REQUEST_TOKEN_METHOD:-POST} "$request_token_url" > "$request_token_tmp"
 
 echo "Load this URL: $(curlicue -f "$consumer_tmp" -f "$request_token_tmp" -e "$authorize_url")"
 read -p 'Paste the PIN you got here: ' pin
 
 curlicue -f "$consumer_tmp" -f "$request_token_tmp" ${pin:+-p "oauth_verifier=$pin"} -- \
-    -s -X POST "$access_token_url" > "$access_token_tmp"
+    -s -X ${CURLICUE_ACCESS_TOKEN_METHOD:-POST} "$access_token_url" > "$access_token_tmp"
 
 paste -d '&' "$consumer_tmp" "$access_token_tmp" > "$output_creds"
 echo "OK! Now you can run: curlicue -f $output_creds [-- CURL_OPTS] URL"


### PR DESCRIPTION
I am working with an API that uses GET instead of POST for their request_token and access_token URLs.  This change allows me to use curlicue against that API with minimal changes.  I'm open to other ways of passing the data as well.